### PR TITLE
Tweaks to set up heroku app

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -44,7 +44,7 @@
 
 ##### Set Up Heroku App & Database
 - `createdb name_of_app` creates psql database locally
-- `heroku apps:create name_of_app` creates a heroku app
+- `heroku apps:create name-of-app` creates a heroku app (Name must start with a letter and can only contain lowercase letters, numbers, and dashes.)
 - `heroku addons:create heroku-postgresql --app name_of_app` adds postgresql database to the app
 - `heroku config` returns the URL
   * add URL to .env file `DATABASE_URL=yourURL?ssl=true`


### PR DESCRIPTION
Changed the example of creating a custom heroku app name to use dashes instead of snake case to follow the format of heroku apps. Added a description of the requirements of a heroku app name after the example.